### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ terminal_size = "0.4.0"
 unicode-width = "0.2.0"
 unicode-segmentation = "1.2.0"
 arc-swap = "1.7.1"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

As I did for many other of your handy Rust-based tools - let's enable LTO and here!

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 2.9 Mib to 2.2 Mib.

Thank you.